### PR TITLE
Ensure the subdevice range properties require their parent

### DIFF
--- a/rdm-schema.json
+++ b/rdm-schema.json
@@ -55,8 +55,10 @@
   "required": [ "pid", "version" ],
   "dependentRequired": {
     "get_request": [ "get_response" ],
+    "get_request_subdevice_range": [ "get_request" ],
     "get_response": [ "get_request" ],
     "set_request": [ "set_response" ],
+    "set_request_subdevice_range": [ "set_request" ],
     "set_response": [ "set_request" ]
   },
   "$defs": {


### PR DESCRIPTION
Even if they're optional, when they are used they should require what they are ranging